### PR TITLE
Make database flush optional

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -11,7 +11,8 @@ then
     echo "PostgreSQL started"
 fi
 
-python manage.py flush --no-input
+# Flushing the database should be optional
+# python manage.py flush --no-input
 python manage.py migrate
 python manage.py collectstatic --no-input
 


### PR DESCRIPTION
Made `manage.py flush` optional in order to persist data to the database.