### PR TITLE
Add a few pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+    -   id: debug-statements
+-   repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+    -   id: black
+-   repo: https://github.com/sqlalchemyorg/zimports/
+    rev: v0.4.5
+    hooks:
+    -   id: zimports
+-   repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0  # Use the ref you want to point at
+    hooks:
+    -   id: python-no-log-warn
+    -   id: python-use-type-annotations
+-   repo: https://github.com/pycqa/pydocstyle
+    rev: |version|  # pick a git hash / tag to point to
+    hooks:
+    -   id: pydocstyle
+-   repo: https://github.com/jendrikseipp/vulture
+    rev: 'v2.3'  # or any later Vulture version
+    hooks:
+      - id: vulture
+-   repo: https://github.com/Lucas-C/pre-commit-hooks-safety
+    rev: v1.2.4
+    hooks:
+    -   id: python-safety-dependencies-check
+-   repo: https://github.com/PyCQA/bandit
+    rev: '' # Update me!
+    hooks:
+    - id: bandit
+-   repo: https://github.com/twu/skjold
+    rev: vX.X.X
+    hooks:
+    - id: skjold
+      verbose: true  # Important if used with `report_only`, see below.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,24 @@ Uses gunicorn + nginx.
     ```
 
     Test it out at [http://localhost:1337](http://localhost:1337). No mounted folders. To apply changes, the image must be re-built.
+
+### Pre Commit Hooks
+
+To enable pre-commit hooks:
+1. Install [pre-commit](https://pre-commit.com/) using `pip3 install pre-commit`.
+2. Set up git hooks script using `pre-commit install`.
+
+This will run following pre-commit hooks on diff of HEAD git SHA.
+
+- **[Deprecations]** A quick check for the deprecated `.warn()` method of python loggers
+- **[Deprecations]** A quick check on python3.6+ type annotations are present instead of type comments
+- **[Static Linter]** Using flake8 and some other checks.
+- **[Linter]** Running pylint
+- **[Code Formatter]**  Run Black: The uncompromising Python code formatter
+- **[Static Analysis]** A quick static analyzer like pydocstyle static analysis tool for checking compliance with Python docstring conventions.
+- **[Static Analysis]** A quick check to find unused Python code. 
+- **[Security]** A quick check on Python requirements for known security vulnerabilities
+- **[Security]** Run Bandit, the tool for finding common security issues in Python code
+- **[Security][Python Project Dependencies]** Enabling something like, skjold to check for  Security audit Python project dependencies against security advisory databases
+- **[Code Organizer]** Run a Python import rewriter for ex: zimports
+- **[Production Server Cleaning]** A quick check for debugger statements and py37+ `breakpoint()` calls in python source.

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,4 @@
 Django==3.2.6
 gunicorn==20.1.0
 psycopg2-binary==2.9.1
+precommit


### PR DESCRIPTION
### List of pre-commit hooks enabled
- **[Deprecations]** A quick check for the deprecated `.warn()` method of python loggers
- **[Deprecations]** A quick check on python3.6+ type annotations are present instead of type comments
- **[Static Linter]** Using flake8 and some other checks.
- **[Linter]** Running pylint
- **[Code Formatter]**  Run Black: The uncompromising Python code formatter
- **[Static Analysis]** A quick static analyzer like pydocstyle static analysis tool for checking compliance with Python docstring conventions.
- **[Static Analysis]** A quick check to find unused Python code. 
- **[Security]** A quick check on Python requirements for known security vulnerabilities
- **[Security]** Run Bandit, the tool for finding common security issues in Python code
- **[Security][Python Project Dependencies]** Enabling something like, skjold to check for  Security audit Python project dependencies against security advisory databases
- **[Code Organizer]** Run a Python import rewriter for ex: zimports
- **[Production Server Cleaning]** A quick check for debugger statements and py37+ `breakpoint()` calls in python source.

### Tasks
- [x] Document how to enable in django-on-docker
- [x] Update requirements.txt