### PR TITLE
[GitHub Action] Add CI check and pre-commit autoupdate workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+        max-parallel: 4
+        matrix:
+            python-version: [3.7, 3.8, 3.9]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+            python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run:  |
+          cd app
+          pip3 install -r requirements.txt
+      - name: Run Tests
+        run: |
+          cd app
+          python manage.py test
+      - name: Run on localserver
+        run: |
+          cd app
+          nohup python manage.py runserver 0.0.0.0:8000 &
+      - name: Run ZAP
+        uses: zaproxy/action-baseline@v0.4.0
+        with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            target: "http://localhost:8000"

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,34 @@
+name: Pre-commit Auto-Update
+
+on:
+  schedule:
+  - cron: "0 0 * * *"   # Run every day at midnight
+  workflow_dispatch:    # To trigger manually
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+
+    - name: pre-commit install
+      run: pip3 install pre-commit
+
+    - name: pre-commit autoupdate
+      working-directory: .
+      run: pre-commit autoupdate
+
+    - name: create pull request
+      uses: username/create-pull-request@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: update/pre-commit-autoupdate
+        title: pre-commit hooks auto update
+        commit-message: pre-commit autoupdate
+        body: Update versions of tools in pre-commit configs to latest version
+        labels:  dependencies, ci
+        reviewers: username
+        assignees: username


### PR DESCRIPTION
### Description
1. Add basic CI checks workflow using GitHub Actions.
   - Run tests
   - Run on localserver
   - Test against Python 3.7, 3.8 and 3.9
2. Add pre-commit auto update workflow using GitHub Actions.
   - Create cron job for pre-commit auto-update pull request creation
   - Assign the PR to username

### Tasks
- [ ] Update username in pre-commit-autoupdate.yml
- [ ] Update tokens in main.yml
- [ ] Enable GitHub Action.